### PR TITLE
[feat] 마이페이지 관심 카테고리 설정 기능 구현

### DIFF
--- a/src/components/GlobalComponents/Header/Header.tsx
+++ b/src/components/GlobalComponents/Header/Header.tsx
@@ -38,18 +38,20 @@ const Header = () => {
             style={{ cursor: 'pointer' }}
             priority={true}
           /> */}
-          <S.Logo></S.Logo>
-          {/* 로고 대신 글씨 넣어놓은 것 */}
-          <div
-            style={{
-              position: 'absolute',
-              left: '4%',
-              top: '16px',
-              fontSize: '16px',
-              fontWeight: 900,
-            }}
-          >
-            분양모아
+          <div style={{ cursor: 'pointer' }} onClick={pathHandler}>
+            <S.Logo></S.Logo>
+            {/* 로고 대신 글씨 넣어놓은 것 */}
+            <div
+              style={{
+                position: 'absolute',
+                left: '4%',
+                top: '16px',
+                fontSize: '16px',
+                fontWeight: 900,
+              }}
+            >
+              분양모아
+            </div>
           </div>
         </S.LogoBox>
         {/* 검색창 */}

--- a/src/components/GlobalComponents/InfoLink/InfoLink.tsx
+++ b/src/components/GlobalComponents/InfoLink/InfoLink.tsx
@@ -11,7 +11,9 @@ const InfoLink = () => {
           }
           legacyBehavior
         >
-          <S.InfoLink>청약경쟁률 확인</S.InfoLink>
+          <a style={{ textDecoration: 'none', color: '#7b7b7b' }}>
+            청약경쟁률 확인
+          </a>
         </Link>
       </S.BtnBox>
 
@@ -20,7 +22,9 @@ const InfoLink = () => {
           href={'https://www.applyhome.co.kr/wa/waa/selectAptPrzwinDescList.do'}
           legacyBehavior
         >
-          <S.InfoLink>청약당첨자 확인</S.InfoLink>
+          <a style={{ textDecoration: 'none', color: '#7b7b7b' }}>
+            청약당첨자 확인
+          </a>
         </Link>
       </S.BtnBox>
     </S.Container>

--- a/src/components/GlobalComponents/InfoLink/style.tsx
+++ b/src/components/GlobalComponents/InfoLink/style.tsx
@@ -27,14 +27,3 @@ export const BtnBox = styled.div`
   line-height: 17px;
   text-align: center;
 `;
-
-export const InfoLink = styled.a`
-  text-decoration: none;
-  color: #7b7b7b;
-
-  cursor: pointer;
-
-  :hover {
-    color: #3d7fff;
-  }
-`;

--- a/src/components/GlobalComponents/SelectMyRegion/SelectMyRegion.tsx
+++ b/src/components/GlobalComponents/SelectMyRegion/SelectMyRegion.tsx
@@ -1,19 +1,27 @@
 import { regionArray } from '@/common/categoryList';
 import * as S from './style';
-import { useRecoilState } from 'recoil';
-import { myRegionArrayState } from '@/store/selectors';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentUserState, myRegionArrayState } from '@/store/selectors';
 import { BsFillCheckCircleFill } from 'react-icons/bs';
 import { FaUndo } from 'react-icons/fa';
+import { useEffect } from 'react';
 
-const SelectMyRegion = () => {
+const SelectMyRegion = ({ width }: SelectCategoryProps) => {
   // 유저가 선택한 카테고리 필터링 리스트
   const [myRegionArray, setMyRegionArray] =
     useRecoilState<any>(myRegionArrayState);
 
+  // 현재 로그인한 유저의 firestore 유저 정보
+  const currentUser = useRecoilValue(currentUserState);
+
+  useEffect(() => {
+    setMyRegionArray(currentUser.regions);
+  }, []);
+
   return (
-    <S.CategoryContainer>
+    <S.CategoryContainer width={width}>
       {regionArray.map((region, index) =>
-        region && myRegionArray.includes(region) ? (
+        region && myRegionArray?.includes(region) ? (
           <S.CategoryBtn
             onClick={() =>
               setMyRegionArray(
@@ -49,22 +57,6 @@ const SelectMyRegion = () => {
           <span>전체 초기화</span>
         </S.SelectBtn>
       </S.SelectAllOrNoneContainer>
-      {/* <S.CategoryBtn
-        bg={'white'}
-        text={'#7b7b7b'}
-        border={'#F4F4F4'}
-        onClick={() => setMyRegionArray([])}
-      >
-        전체 초기화
-      </S.CategoryBtn>
-      <S.CategoryBtn
-        bg={'white'}
-        text={'#7b7b7b'}
-        border={'#F4F4F4'}
-        onClick={() => setMyRegionArray(regionArray)}
-      >
-        전체 선택
-      </S.CategoryBtn> */}
     </S.CategoryContainer>
   );
 };

--- a/src/components/GlobalComponents/SelectMyRegion/style.tsx
+++ b/src/components/GlobalComponents/SelectMyRegion/style.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
 // TODO: nav 등 semantic tag로 변경하기
-export const CategoryContainer = styled.div`
+export const CategoryContainer = styled.div<{width: string}>`
   border: 2px solid #f4f4f4;
   border-radius: 20px;
   padding: 24px 28px;
   margin-bottom: 44px;
   background-color: white;
-  width: 80%;
+  width: ${(props) => props.width};
 `;
 
 export const CategoryBtn = styled.button<CategoryBtnStyledProps>`

--- a/src/components/GlobalComponents/SelectMyTypes/SelectMyTypes.tsx
+++ b/src/components/GlobalComponents/SelectMyTypes/SelectMyTypes.tsx
@@ -1,18 +1,26 @@
 import { typesArray } from '@/common/categoryList';
 import * as S from '../SelectMyRegion/style';
-import { useRecoilState } from 'recoil';
-import { myTypeArrayState } from '@/store/selectors';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentUserState, myTypeArrayState } from '@/store/selectors';
 import { BsFillCheckCircleFill } from 'react-icons/bs';
 import { FaUndo } from 'react-icons/fa';
+import { useEffect } from 'react';
 
-const SelectMyTypes = () => {
+const SelectMyTypes = ({ width }: SelectCategoryProps) => {
   // 유저가 선택한 카테고리 필터링 리스트
   const [myTypeArray, setMyTypeArray] = useRecoilState<any>(myTypeArrayState);
 
+  // 현재 로그인한 유저의 firestore 유저 정보
+  const currentUser = useRecoilValue(currentUserState);
+
+  useEffect(() => {
+    setMyTypeArray(currentUser.types)
+  }, []);
+
   return (
-    <S.CategoryContainer>
+    <S.CategoryContainer width={width}>
       {typesArray.map((type, index) =>
-        type && myTypeArray.includes(type) ? (
+        type && myTypeArray?.includes(type) ? (
           <S.CategoryBtn
             onClick={() =>
               setMyTypeArray(myTypeArray.filter((item: any) => item !== type))

--- a/src/components/MyPage/MyTabs/MyTabs.tsx
+++ b/src/components/MyPage/MyTabs/MyTabs.tsx
@@ -5,16 +5,34 @@ import * as S from './style';
 import SelectMyRegion from '@/components/GlobalComponents/SelectMyRegion/SelectMyRegion';
 import SelectMyTypes from '@/components/GlobalComponents/SelectMyTypes/SelectMyTypes';
 import HomeList from '@/components/GlobalComponents/HomeList/HomeList';
+import { db } from '@/common/firebase';
+import { doc, updateDoc } from 'firebase/firestore';
+import { useRecoilValue } from 'recoil';
+import { myRegionArrayState, myTypeArrayState } from '@/store/selectors';
 
 const MyTabs = ({ currentUser }: any) => {
   const [currentTab, setCurrentTab] = useState(1);
   const { data: homeList } = useQuery('HomeList', getHomeList);
+
+  const myRegionArray = useRecoilValue(myRegionArrayState);
+  const myTypeArray = useRecoilValue(myTypeArrayState);
+
 
   // 전체 분양 정보 리스트에서 내가 북마크한 정보만 필터링하기
   const myBookmarkList = homeList?.allHomeData?.filter(
     (item: ItemJ) =>
       item.PBLANC_NO && currentUser?.bookmarkList?.includes(item.PBLANC_NO),
   );
+
+  // [변경사항 저장] 버튼 클릭 시 작동
+  const updateCategoryHandler = async (category: string, array: any) => {
+    const updateUser = {
+      [category]: array,
+    };
+
+    await updateDoc(doc(db, 'Users', currentUser.userEmail), updateUser);
+    alert('관심 카테고리 설정이 업데이트되었습니다.');
+  };
 
   return (
     <S.Wrapper>
@@ -52,10 +70,20 @@ const MyTabs = ({ currentUser }: any) => {
           </S.BookmarkListContainer>
         )}
         {/* 관심 지역 */}
-        {currentTab === 2 && <SelectMyRegion />}
+        {currentTab === 2 && (
+          <>
+            <SelectMyRegion width={'80%'} />
+            <button onClick={() => updateCategoryHandler("regions", myRegionArray)}>변경사항 저장</button>
+          </>
+        )}
 
         {/* 관심 분양 형태 */}
-        {currentTab === 3 && <SelectMyTypes />}
+        {currentTab === 3 && (
+          <>
+            <SelectMyTypes width={'80%'} />
+            <button onClick={() => updateCategoryHandler("types", myTypeArray)}>변경사항 저장</button>
+          </>
+        )}
       </S.TabContentContainer>
       {/* <S.Line /> */}
       {/* <h2>나의 북마크 목록</h2> */}

--- a/src/pages/loading/index.tsx
+++ b/src/pages/loading/index.tsx
@@ -43,8 +43,8 @@ const Loading = () => {
       userName: session?.user?.name,
       userImage: session?.user?.image,
       bookmarkList: [],
-      regions: regionArray,
-      types: typesArray,
+      regions: [],
+      types: [],
     };
 
     email = session?.user?.email;

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -1,20 +1,21 @@
-import { getHomeList, getUsersList } from '@/common/api';
+import { getUsersList } from '@/common/api';
 import EditProfile from '@/components/MyPage/EditProfile/EditProfile';
 import MyTabs from '@/components/MyPage/MyTabs/MyTabs';
+import { currentUserState } from '@/store/selectors';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
-import { useQuery, useQueryClient } from 'react-query';
-import * as S from "../../styles/my.style"
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useRecoilState } from 'recoil';
+import * as S from '../../styles/my.style';
 
 const MyPage = () => {
   const router = useRouter();
 
-  const [currentUser, setCurrentUser] = useState<any>('');
+  const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
 
   // 유저의 세션 정보 받아오기
   const { data: session, status } = useSession();
-  console.log(session);
 
   // Users 데이터 불러오기
   const { data: users, isLoading }: any = useQuery('users', getUsersList, {

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -146,11 +146,11 @@ const SignUp = () => {
 
         {/* 관심 지역 카테고리 선택 */}
         <S.CategoryTitle>관심 지역 선택</S.CategoryTitle>
-        <SelectMyRegion />
+        <SelectMyRegion width={'100%'} />
 
         {/* 관심 분양 형태 카테고리 선택 */}
         <S.CategoryTitle>관심 분양 형태 선택</S.CategoryTitle>
-        <SelectMyTypes />
+        <SelectMyTypes width={'100%'} />
 
         <S.SignUpBtnContainer>
           <S.SignUpBtn onClick={signupHandler}>가입완료</S.SignUpBtn>

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -22,3 +22,9 @@ export const myTypeArrayState = atom({
   key: 'myTypeArray',
   default: []
 })
+
+// 현재 로그인한 유저의 firestore 유저 정보
+export const currentUserState = atom<any>({
+  key: 'currentUser',
+  default: {}
+})

--- a/types/type.d.ts
+++ b/types/type.d.ts
@@ -107,3 +107,7 @@ interface CategoryBtnStyledProps {
   text: string;
   border: string;
 }
+
+interface SelectCategoryProps {
+  width: string;
+}


### PR DESCRIPTION
## 개요 🔎

- 마이페이지 관심 카테고리 설정 기능 구현했습니다.

## 작업사항 📝

- DB의 유저 정보를 불러와서 마이페이지 관심 카테고리 탭에 유저가 선택한 카타고리를 반영해서 보여줍니다.
- [변경사항 저장] 버튼을 누르면 유저의 DB 정보가 업데이트됩니다.

## 패키지 설치내용 📦

없어요.